### PR TITLE
Updating polars kwargs for scan/read_csv and LazyFrame operations

### DIFF
--- a/polars_queries/q2.py
+++ b/polars_queries/q2.py
@@ -53,7 +53,7 @@ def q():
             reverse=[True, False, False, False],
         )
         .limit(100)
-        .with_column(pl.col(pl.datatypes.Utf8).str.strip().keep_name())
+        .with_columns(pl.col(pl.datatypes.Utf8).str.strip().keep_name())
     )
 
     utils.run_query(Q_NUM, q_final)

--- a/polars_queries/q3.py
+++ b/polars_queries/q3.py
@@ -21,7 +21,7 @@ def q():
         .join(line_item_ds, left_on="o_orderkey", right_on="l_orderkey")
         .filter(pl.col("o_orderdate") < var2)
         .filter(pl.col("l_shipdate") > var1)
-        .with_column(
+        .with_columns(
             (pl.col("l_extendedprice") * (1 - pl.col("l_discount"))).alias("revenue")
         )
         .groupby(["o_orderkey", "o_orderdate", "o_shippriority"])

--- a/polars_queries/q4.py
+++ b/polars_queries/q4.py
@@ -23,7 +23,7 @@ def q():
         .groupby("o_orderpriority")
         .agg(pl.count().alias("order_count"))
         .sort(by="o_orderpriority")
-        .with_column(pl.col("order_count").cast(pl.datatypes.Int64))
+        .with_columns(pl.col("order_count").cast(pl.datatypes.Int64))
     )
 
     utils.run_query(Q_NUM, q_final)

--- a/polars_queries/q5.py
+++ b/polars_queries/q5.py
@@ -32,7 +32,7 @@ def q():
         .filter(pl.col("r_name") == var1)
         .filter(pl.col("o_orderdate") >= var2)
         .filter(pl.col("o_orderdate") < var3)
-        .with_column(
+        .with_columns(
             (pl.col("l_extendedprice") * (1 - pl.col("l_discount"))).alias("revenue")
         )
         .groupby("n_name")

--- a/polars_queries/q7.py
+++ b/polars_queries/q7.py
@@ -41,10 +41,10 @@ def q():
         pl.concat([df1, df2])
         .filter(pl.col("l_shipdate") >= datetime(1995, 1, 1))
         .filter(pl.col("l_shipdate") <= datetime(1996, 12, 31))
-        .with_column(
+        .with_columns(
             (pl.col("l_extendedprice") * (1 - pl.col("l_discount"))).alias("volume")
         )
-        .with_column(pl.col("l_shipdate").dt.year().alias("l_year"))
+        .with_columns(pl.col("l_shipdate").dt.year().alias("l_year"))
         .groupby(["supp_nation", "cust_nation", "l_year"])
         .agg([pl.sum("volume").alias("revenue")])
         .sort(by=["supp_nation", "cust_nation", "l_year"])

--- a/polars_queries/utils.py
+++ b/polars_queries/utils.py
@@ -34,7 +34,7 @@ def _scan_ds(path: str):
 
 def get_query_answer(query: int, base_dir: str = ANSWERS_BASE_DIR) -> pl.LazyFrame:
     answer_ldf = pl.scan_csv(
-        join(base_dir, f"q{query}.out"), sep="|", has_header=True, parse_dates=True
+        join(base_dir, f"q{query}.out"), separator="|", has_header=True, try_parse_dates=True
     )
     cols = answer_ldf.columns
     answer_ldf = answer_ldf.select(

--- a/prepare_files.py
+++ b/prepare_files.py
@@ -103,8 +103,8 @@ for name in [
     df = pl.read_csv(
         f"tables_scale_{scale_fac}/{name}.tbl",
         has_header=False,
-        sep="|",
-        parse_dates=True,
+        separator="|",
+        try_parse_dates=True,
         new_columns=eval(f"h_{name}"),
     )
     print(df.shape)

--- a/prepare_large_files.py
+++ b/prepare_large_files.py
@@ -111,8 +111,8 @@ for name in [
     df = pl.scan_csv(
             f"tables_scale_{scale_fac}/{name}.tbl",
             has_header=False,
-            sep="|",
-            parse_dates=True,
+            separator="|",
+            try_parse_dates=True,
             with_column_names= lambda _: eval(f"h_{name}")
         )
 

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -50,7 +50,7 @@ def add_annotations(fig, limit: int, df: pl.DataFrame):
     # and create a text label for them
     df = (
         df.filter(pl.col("duration[s]") > limit)
-        .with_column(
+        .with_columns(
             pl.when(pl.col("success"))
             .then(
                 pl.format(
@@ -62,7 +62,7 @@ def add_annotations(fig, limit: int, df: pl.DataFrame):
         .join(bar_order, on="solution")
         .groupby("query_no")
         .agg([pl.col("labels").list(), pl.col("index").min()])
-        .with_column(pl.col("labels").arr.join(",\n"))
+        .with_columns(pl.col("labels").arr.join(",\n"))
     )
 
     # then we create a dictionary similar to something like this:


### PR DESCRIPTION
There has been a good bit of changes with polars keywords. This PR looks to adjust the polars usage for compatibility around these updates. 

- scan_csv was updated a little while ago to change sep to separator per https://github.com/pola-rs/polars/pull/7533.
- reverse got renamed to descending as well per https://github.com/pola-rs/polars/pull/6914.
- with_column was renamed as well to with_columns per https://github.com/pola-rs/polars/pull/6128.

Closes #41 