### PR TITLE
Add script to create dot plot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ vaex
 pyspark
 duckdb
 pandas>=2.0
+plotnine

--- a/scripts/plot_dots.py
+++ b/scripts/plot_dots.py
@@ -74,10 +74,11 @@ def prepare_timings(
             & ~pl.col("solution").is_in(exclude_solutions)
         )
         .select(
-            (pl.col("name") + " (" + pl.col("version") + ")").alias("solution"),
+            pl.col("solution"),
+            pl.col("name"),
+            (pl.col("name") + " (" + pl.col("version") + ")").alias("name_version"),
             pl.col("query_no").alias("query"),
             pl.col("duration[s]").alias("duration"),
-            pl.col("name"),
         )
     )
 
@@ -156,15 +157,17 @@ def create_plot(
         },
     }
 
+    styles = styles.join(timings, on="solution", how="semi")
+
     plot = (
         p9.ggplot(
             timings,
             p9.aes(
                 x="duration",
                 y="query",
-                fill="solution",
-                shape="solution",
-                size="solution",
+                fill="name_version",
+                shape="name_version",
+                size="name_version",
             ),
         )
         + p9.geom_point(alpha=1, color="black")

--- a/scripts/plot_dots.py
+++ b/scripts/plot_dots.py
@@ -2,15 +2,52 @@
 
 import sys
 import argparse
-import fileinput
-from typing import List, Tuple
+import textwrap
+import warnings
 
 try:
     import polars as pl
     import plotnine as p9
+
+    from plotnine.exceptions import PlotnineWarning
+
+    warnings.filterwarnings("ignore", category=PlotnineWarning)
 except ImportError:
     print("Please install Polars and Plotnine to use this script.")
     sys.exit(1)
+
+
+def get_styles(exclude_solutions: list[str]):
+    all_styles = pl.from_repr(
+        """
+        ┌──────────┬──────────┬─────────┬───────┬──────┐
+        │ solution ┆ name     ┆ color   ┆ shape ┆ size │
+        │ ---      ┆ ---      ┆ ---     ┆ ---   ┆ ---  │
+        │ str      ┆ str      ┆ str     ┆ str   ┆ f32  │
+        ╞══════════╪══════════╪═════════╪═══════╪══════╡
+        │ dask     ┆ Dask     ┆ #ef1161 ┆ D     ┆ 4.5  │
+        │ duckdb   ┆ DuckDB   ┆ #fff000 ┆ o     ┆ 5.0  │
+        │ modin    ┆ Modin    ┆ #00abee ┆ >     ┆ 5.0  │
+        │ pandas   ┆ Pandas   ┆ #e70488 ┆ s     ┆ 5.0  │
+        │ polars   ┆ Polars   ┆ #adbac7 ┆ p     ┆ 6.0  │
+        │ spark    ┆ Spark    ┆ #e25a1c ┆ *     ┆ 7.0  │
+        │ vaex     ┆ Vaex     ┆ #585858 ┆ v     ┆ 6.0  │
+        └──────────┴──────────┴─────────┴───────┴──────┘
+"""
+    )
+
+    return all_styles.filter(~pl.col("solution").is_in(exclude_solutions))
+
+
+def parse_queries(s: str) -> list[str]:
+    int_set = set()
+    for part in s.split(","):
+        if "-" in part:
+            start, end = map(int, part.split("-"))
+            int_set.update(range(start, end + 1))
+        else:
+            int_set.add(int(part))
+    return [f"q{x}" for x in sorted(list(int_set))]
 
 
 def read_csv(filename: str) -> pl.DataFrame:
@@ -21,15 +58,143 @@ def read_csv(filename: str) -> pl.DataFrame:
     return df
 
 
-def create_plot(
-    df: pl.DataFrame,
+def prepare_timings(
+    timings: pl.DataFrame,
+    styles: pl.DataFrame,
+    exclude_solutions: list[str],
+    queries: list[str],
+    include_io: bool,
+):
+    return (
+        timings.join(styles, on="solution", how="left")
+        .filter(
+            pl.col("success")
+            & pl.col("query_no").is_in(queries)
+            & (pl.col("include_io") == include_io)
+            & ~pl.col("solution").is_in(exclude_solutions)
+        )
+        .select(
+            (pl.col("name") + " (" + pl.col("version") + ")").alias("solution"),
+            pl.col("query_no").alias("query"),
+            pl.col("duration[s]").alias("duration"),
+            pl.col("name"),
+        )
+    )
+
+
+def formulate_caption(
+    timings: pl.DataFrame,
+    styles: pl.DataFrame,
+    queries: list[str],
     max_duration: float,
-    output: str,
-    mode: str,
-    height: float,
     width: float,
+):
+    exceeded_timings = timings.filter(pl.col("duration") > max_duration).select(
+        pl.col("name"),
+        pl.col("query"),
+        (
+            pl.lit("took ")
+            + pl.col("duration").round(1).cast(pl.Utf8)
+            + "s on "
+            + pl.col("query")
+        ).alias("text"),
+    )
+
+    all_combinations_df = styles.select("name").join(
+        pl.DataFrame({"query": queries}), how="cross"
+    )
+
+    missing_timings = all_combinations_df.join(
+        timings, how="anti", on=["name", "query"]
+    ).with_columns((pl.lit("failed on ") + pl.col("query")).alias("text"))
+
+    notes_df = pl.concat([exceeded_timings, missing_timings]).sort("name", "query")
+
+    notes = []
+    for name, group in notes_df.group_by("name"):
+        texts = group.get_column("text")
+        join_char = ", " if len(texts) >= 3 else " "
+
+        if len(texts) >= 2:
+            texts[-1] = "and " + texts[-1]
+
+        notes.append(f"{name} {join_char.join(texts)}.")
+
+    caption = f"Note: {' '.join(notes)} " if notes else ""
+    caption += "More information: https://www.pola.rs/benchmarks.html"
+    caption = "\n".join(textwrap.wrap(caption, int(width * 15 - 20)))
+    return caption
+
+
+def create_plot(
+    timings: pl.DataFrame,
+    styles: pl.DataFrame,
+    queries: list[str],
+    include_io: bool,
+    max_duration: float,
+    caption: str,
+    mode: str,
+    width: float,
+    height: float,
+    dpi: float,
 ) -> None:
-    pass
+    if include_io:
+        subtitle = "Results including reading parquet (lower is better)"
+    else:
+        subtitle = "Results starting from in-memory data (lower is better)"
+
+    theme = {
+        "dark": {
+            "background_color": "#0d1117",
+            "text_color": "#adbac7",
+            "line_color": "#999",
+        },
+        "light": {
+            "background_color": "#fff",
+            "text_color": "#333",
+            "line_color": "#999",
+        },
+    }
+
+    plot = (
+        p9.ggplot(
+            timings,
+            p9.aes(
+                x="duration",
+                y="query",
+                fill="solution",
+                shape="solution",
+                size="solution",
+            ),
+        )
+        + p9.geom_point(alpha=1, color="black")
+        + p9.scale_x_continuous(limits=(0, max_duration))
+        + p9.scale_y_discrete(limits=queries[::-1])
+        + p9.scale_fill_manual(values=styles.get_column("color"))
+        + p9.scale_shape_manual(values=styles.get_column("shape"))
+        + p9.scale_size_manual(values=styles.get_column("size"))
+        + p9.labs(
+            title="TPCH Benchmark",
+            subtitle=subtitle,
+            caption=caption,
+            x="duration (s)",
+        )
+        + p9.theme_tufte(ticks=False)
+        + p9.theme(
+            text=p9.element_text(color=theme[mode]["text_color"]),
+            plot_title=p9.element_text(size=18, weight=800),
+            plot_background=p9.element_rect(fill=theme[mode]["background_color"]),
+            panel_grid_major_y=p9.element_line(color=theme[mode]["line_color"]),
+            legend_title=p9.element_blank(),
+            plot_subtitle=p9.element_text(margin={"b": 20}),
+            plot_caption=p9.element_text(
+                ha="left", linespacing=2, style="italic", margin={"t": 20}
+            ),
+            figure_size=(width, height),
+            dpi=dpi,
+        )
+    )
+    return plot
 
 
 def main() -> None:
@@ -53,6 +218,22 @@ def main() -> None:
         metavar="<seconds>",
     )
     parser.add_argument(
+        "-q",
+        "--queries",
+        type=str,
+        default="1-8",
+        help="Queries to include",
+        metavar="<integers and ranges>",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude",
+        type=str,
+        default="",
+        help="Solutions to exclude",
+        metavar="<list of solutions>",
+    )
+    parser.add_argument(
         "-i",
         "--include-io",
         action="store_true",
@@ -67,6 +248,13 @@ def main() -> None:
         help="Theme mode",
     )
     parser.add_argument(
+        "--width",
+        type=float,
+        default=8.0,
+        help="Figure width",
+        metavar="<inch>",
+    )
+    parser.add_argument(
         "--height",
         type=float,
         default=4.0,
@@ -74,11 +262,11 @@ def main() -> None:
         metavar="<inch>",
     )
     parser.add_argument(
-        "--width",
+        "--dpi",
         type=float,
-        default=8.0,
-        help="Figure width",
-        metavar="<inch>",
+        default=200,
+        help="Figure DPI",
+        metavar="<dpi>",
     )
     parser.add_argument(
         "-o",
@@ -91,8 +279,28 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    df = read_csv(args.csv)
-    print(df.head())
+    exclude_solutions = args.exclude.split(",")
+    styles = get_styles(exclude_solutions)
+    queries = parse_queries(args.queries)
+    timings = prepare_timings(
+        read_csv(args.csv), styles, exclude_solutions, queries, args.include_io
+    )
+    caption = formulate_caption(timings, styles, queries, args.max_duration, args.width)
+
+    plot = create_plot(
+        timings,
+        styles,
+        queries,
+        include_io=args.include_io,
+        max_duration=args.max_duration,
+        caption=caption,
+        mode=args.mode,
+        width=args.width,
+        height=args.height,
+        dpi=args.dpi,
+    )
+
+    plot.save(args.output)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_dots.py
+++ b/scripts/plot_dots.py
@@ -33,7 +33,7 @@ def get_styles(exclude_solutions: list[str]):
         │ spark    ┆ Spark    ┆ #e25a1c ┆ *     ┆ 7.0  │
         │ vaex     ┆ Vaex     ┆ #585858 ┆ v     ┆ 6.0  │
         └──────────┴──────────┴─────────┴───────┴──────┘
-"""
+        """
     )
 
     return all_styles.filter(~pl.col("solution").is_in(exclude_solutions))
@@ -183,7 +183,10 @@ def create_plot(
         + p9.theme(
             text=p9.element_text(color=theme[mode]["text_color"]),
             plot_title=p9.element_text(size=18, weight=800),
-            plot_background=p9.element_rect(fill=theme[mode]["background_color"]),
+            plot_background=p9.element_rect(
+                color=theme[mode]["background_color"],
+                fill=theme[mode]["background_color"],
+            ),
             panel_grid_major_y=p9.element_line(color=theme[mode]["line_color"]),
             legend_title=p9.element_blank(),
             plot_subtitle=p9.element_text(margin={"b": 20}),

--- a/scripts/plot_dots.py
+++ b/scripts/plot_dots.py
@@ -113,7 +113,9 @@ def formulate_caption(
             timings, how="anti", on=["name", "query"]
         ).with_columns((pl.lit("failed on ") + pl.col("query")).alias("text"))
 
-        notes_df = pl.concat([exceeded_timings, missing_timings]).sort("name", "query")
+        notes_df = pl.concat([exceeded_timings, missing_timings]).sort(
+            pl.col("name"), pl.col("query").str.slice(1).cast(pl.Int8)
+        )
 
         notes = []
         for name, group in notes_df.group_by("name"):

--- a/scripts/plot_dots.py
+++ b/scripts/plot_dots.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+import fileinput
+from typing import List, Tuple
+
+try:
+    import polars as pl
+    import plotnine as p9
+except ImportError:
+    print("Please install Polars and Plotnine to use this script.")
+    sys.exit(1)
+
+
+def read_csv(filename: str) -> pl.DataFrame:
+    if filename == "-":
+        df = pl.read_csv(sys.stdin.buffer)
+    else:
+        df = pl.read_csv(filename)
+    return df
+
+
+def create_plot(
+    df: pl.DataFrame,
+    max_duration: float,
+    output: str,
+    mode: str,
+    height: float,
+    width: float,
+) -> None:
+    pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create dot plot from timings CSV file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "csv",
+        nargs="?",
+        default="-",
+        metavar="<csv file>",
+        help="CSV file to read (if not specified, reads from stdin)",
+    )
+    parser.add_argument(
+        "-d",
+        "--max-duration",
+        type=float,
+        default=4.0,
+        help="Maximum duration",
+        metavar="<seconds>",
+    )
+    parser.add_argument(
+        "-i",
+        "--include-io",
+        action="store_true",
+        help="Include I/O time",
+    )
+    parser.add_argument(
+        "-m",
+        "--mode",
+        type=str,
+        choices=["dark", "light"],
+        default="dark",
+        help="Theme mode",
+    )
+    parser.add_argument(
+        "--height",
+        type=float,
+        default=4.0,
+        help="Figure height",
+        metavar="<inch>",
+    )
+    parser.add_argument(
+        "--width",
+        type=float,
+        default=8.0,
+        help="Figure width",
+        metavar="<inch>",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="plot.png",
+        help="Output file",
+        metavar="<png file>",
+    )
+
+    args = parser.parse_args()
+
+    df = read_csv(args.csv)
+    print(df.head())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@ritchie46 and I discussed about improving the current benchmark plots. This PR adds a stand-alone command-line tool `plot_dots.py`, which:

* Creates a dot plot, which is arguably easier to interpret than a bar chart.
* Saves PNG files directly (no need to manually save them from generated HTML).
* Offers dark mode (for the Polars website) and light mode (for, e.g., presentations).
* Explicitly mentions in the caption which solutions failed or took too long on which queries.
* Can include certain queries and exclude specific solutions.
* Uses command-line arguments instead of environment variables.

-- Jeroen

### Help

```console
$ scripts/plot_dots.py --help
usage: plot_dots.py [-h] [-d <seconds>] [-q <integers and ranges>]
                    [-e <list of solutions>] [-i] [-n] [-m {dark,light}] [-t]
                    [--width <inch>] [--height <inch>] [--dpi <dpi>] [-o <png file>]
                    [<csv file>]

Create dot plot from timings CSV file.

positional arguments:
  <csv file>            CSV file to read (if not specified, reads from stdin) (default:
                        -)

options:
  -h, --help            show this help message and exit
  -d <seconds>, --max-duration <seconds>
                        Maximum duration (default: 4.0)
  -q <integers and ranges>, --queries <integers and ranges>
                        Queries to include (default: 1-8)
  -e <list of solutions>, --exclude <list of solutions>
                        Solutions to exclude (default: )
  -i, --include-io      Include I/O time (default: False)
  -n, --no-notes        Don't include failed or exceeded timings in caption (default:
                        False)
  -m {dark,light}, --mode {dark,light}
                        Theme mode (default: dark)
  -t, --transparent     Make figure background transparent (default: False)
  --width <inch>        Figure width (default: 8.0)
  --height <inch>       Figure height (default: 4.0)
  --dpi <dpi>           Figure DPI (default: 200)
  -o <png file>, --output <png file>
                        Output file (default: plot.png)
```

### Default settings

```console
$ scripts/plot_dots.py timings.csv
```

Note: I have not yet managed to install Vaex on my MacBook, hence the many failed notes on it. Plots are saved to plot.png by default.

![plot](https://github.com/pola-rs/tpch/assets/1368256/6c9c4db2-7003-44bb-bca3-1bfeba32bc8d)

### Disable specific solutions and select specific queries

```console
$ scripts/plot_dots.py timings.csv --queries 1-3,5,7-10 --exclude vaex,modin --output plot-exclude.png
```

![plot-exclude](https://github.com/pola-rs/tpch/assets/1368256/4eab2c4b-1c37-47a4-8acf-9959bf0f1443)

### Don't include notes

```console
$ scripts/plot_dots.py timings.csv --no-notes --output plot-no-notes.png
```

![plot-no-notes](https://github.com/pola-rs/tpch/assets/1368256/87216b6e-3022-4ed3-88d9-70a6f5c7012b)

### Light mode

```console
$ scripts/plot_dots.py timings.csv --exclude vaex --mode light --output plot-light.png
```

![plot-light](https://github.com/pola-rs/tpch/assets/1368256/5740037e-2c8e-4f6c-a5ea-c094fdb7c8dc)

### Include I/O time and change max duration

Note: the default max duration is 4.0 seconds

```console
$ scripts/plot_dots.py timings.csv --exclude vaex --mode light --include-io --max-duration 10 --output plot-include-io.png
```

![plot-include-io](https://github.com/pola-rs/tpch/assets/1368256/32fb1f76-7d84-4bce-8e02-f7ae2aade27e)

### Change figure width, height, DPI, and transparent background

Note: the figure theme mode is dark. If you're using GitHub in light mode, the text is indeed too light.

```console
$ scripts/plot_dots.py timings.csv --exclude vaex --transparent --width 8 --height 4.5 --dpi 300 --output plot-settings.png
```

![plot-settings](https://github.com/pola-rs/tpch/assets/1368256/113be02d-1400-41ac-afb9-bd8ddd1f5852)

### OK, one last plot

```console
$ scripts/plot_dots.py timings.csv --exclude dask,modin,pandas,duckdb,vaex --queries 9-20 --mode light --include-io --max-duration 2.5 --height 5 --output plot-some-queries.png
```

![plot-some-queries](https://github.com/pola-rs/tpch/assets/1368256/e6cef5c7-1ee4-4a79-bd41-7ccb25024f0e)


