### PR TITLE
Add setting for running Polars without optimizations

### DIFF
--- a/queries/polars/utils.py
+++ b/queries/polars/utils.py
@@ -66,11 +66,12 @@ def get_part_supp_ds() -> pl.LazyFrame:
 
 def run_query(query_number: int, lf: pl.LazyFrame) -> None:
     streaming = settings.run.polars_streaming
+    eager = settings.run.polars_eager
 
     if settings.run.polars_show_plan:
-        print(lf.explain(streaming=streaming))
+        print(lf.explain(streaming=streaming, optimized=eager))
 
-    query = partial(lf.collect, streaming=streaming)
+    query = partial(lf.collect, streaming=streaming, no_optimization=eager)
     run_query_generic(
         query, query_number, "polars", query_checker=check_query_result_pl
     )

--- a/settings.py
+++ b/settings.py
@@ -30,6 +30,7 @@ class Run(BaseSettings):
     check_results: bool = False  # Only available for SCALE_FACTOR=1
 
     polars_show_plan: bool = False
+    polars_eager: bool = False
     polars_streaming: bool = False
     polars_streaming_groupby: bool = False
 


### PR DESCRIPTION
This allows for a more 'fair' comparison with libraries such as pandas that do no query optimization.