### PR TITLE
add exists -> semi in q4

### DIFF
--- a/queries/dask/q4.py
+++ b/queries/dask/q4.py
@@ -26,12 +26,10 @@ def q() -> None:
         var1 = date(1993, 7, 1)
         var2 = date(1993, 10, 1)
 
-        jn = line_item_ds.merge(orders_ds, left_on="l_orderkey", right_on="o_orderkey")
+        exists = line_item_ds[line_item_ds["l_commitdate"] < line_item_ds["l_receiptdate"]]
 
+        jn = orders_ds.merge(exists, left_on="o_orderkey", right_on="l_orderkey", how="leftsemi")
         jn = jn[(jn["o_orderdate"] >= var1) & (jn["o_orderdate"] < var2)]
-        jn = jn[jn["l_commitdate"] < jn["l_receiptdate"]]
-
-        jn = jn.drop_duplicates(subset=["o_orderpriority", "l_orderkey"])
 
         gb = jn.groupby("o_orderpriority")
         agg = gb.agg(

--- a/queries/dask/q4.py
+++ b/queries/dask/q4.py
@@ -26,9 +26,13 @@ def q() -> None:
         var1 = date(1993, 7, 1)
         var2 = date(1993, 10, 1)
 
-        exists = line_item_ds[line_item_ds["l_commitdate"] < line_item_ds["l_receiptdate"]]
+        exists = line_item_ds[
+            line_item_ds["l_commitdate"] < line_item_ds["l_receiptdate"]
+        ]
 
-        jn = orders_ds.merge(exists, left_on="o_orderkey", right_on="l_orderkey", how="leftsemi")
+        jn = orders_ds.merge(
+            exists, left_on="o_orderkey", right_on="l_orderkey", how="leftsemi"
+        )
         jn = jn[(jn["o_orderdate"] >= var1) & (jn["o_orderdate"] < var2)]
 
         gb = jn.groupby("o_orderpriority")

--- a/queries/polars/q4.py
+++ b/queries/polars/q4.py
@@ -16,11 +16,12 @@ def q() -> None:
 
     q_final = (
         # SQL exists translates to semi join in Polars API
-        orders.join((
-            lineitem.filter(
-                pl.col("l_commitdate") < pl.col("l_receiptdate")
-            )
-        ), left_on="o_orderkey", right_on="l_orderkey", how="semi")
+        orders.join(
+            (lineitem.filter(pl.col("l_commitdate") < pl.col("l_receiptdate"))),
+            left_on="o_orderkey",
+            right_on="l_orderkey",
+            how="semi",
+        )
         .filter(pl.col("o_orderdate").is_between(var1, var2, closed="left"))
         .group_by("o_orderpriority")
         .agg(pl.len().alias("order_count"))

--- a/queries/polars/q4.py
+++ b/queries/polars/q4.py
@@ -15,10 +15,13 @@ def q() -> None:
     var2 = date(1993, 10, 1)
 
     q_final = (
-        lineitem.join(orders, left_on="l_orderkey", right_on="o_orderkey")
+        # SQL exists translates to semi join in Polars API
+        orders.join((
+            lineitem.filter(
+                pl.col("l_commitdate") < pl.col("l_receiptdate")
+            )
+        ), left_on="o_orderkey", right_on="l_orderkey", how="semi")
         .filter(pl.col("o_orderdate").is_between(var1, var2, closed="left"))
-        .filter(pl.col("l_commitdate") < pl.col("l_receiptdate"))
-        .unique(subset=["o_orderpriority", "l_orderkey"])
         .group_by("o_orderpriority")
         .agg(pl.len().alias("order_count"))
         .sort("o_orderpriority")

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 dask[dataframe]
+dask-expr
 duckdb
 modin[ray]
 pandas>=2.0


### PR DESCRIPTION
An SQL `exists` filters left on availability in right. Thus a `semi` join. 

Before we did an inner join + drop-duplicates, which is incorrect.

This makes the Polars query 12% faster.