### PR TITLE
Fix incorrect q14 translation

### DIFF
--- a/queries/polars/q14.py
+++ b/queries/polars/q14.py
@@ -20,7 +20,7 @@ def q() -> None:
         .select(
             (
                 100.00
-                * pl.when(pl.col("p_type").str.contains("PROMO*"))
+                * pl.when(pl.col("p_type").str.starts_with("PROMO"))
                 .then(pl.col("l_extendedprice") * (1 - pl.col("l_discount")))
                 .otherwise(0)
                 .sum()


### PR DESCRIPTION
I'm pretty sure that `.str.contains("PROMO*")` is an accidental mistranslation of `like 'PROMO%'`  😄 It happens to produce the same result for this query/dataset, but wouldn't want someone to learn the wrong thing from it