### PR TITLE
Correct FRACTION substitution parameter for Q11

### DIFF
--- a/queries/duckdb/q11.py
+++ b/queries/duckdb/q11.py
@@ -1,6 +1,9 @@
 import duckdb
 
 from queries.duckdb import utils
+from settings import Settings
+
+settings = Settings()
 
 Q_NUM = 11
 
@@ -9,6 +12,8 @@ def q() -> None:
     supplier_ds = utils.get_supplier_ds()
     part_supp_ds = utils.get_part_supp_ds()
     nation_ds = utils.get_nation_ds()
+    scale_factor = settings.scale_factor
+    fraction = 0.0001 / scale_factor
 
     query_str = f"""
     select
@@ -26,7 +31,7 @@ def q() -> None:
         ps_partkey having
                 sum(ps_supplycost * ps_availqty) > (
             select
-                sum(ps_supplycost * ps_availqty) * 0.0001
+                sum(ps_supplycost * ps_availqty) * {fraction}
             from
                 {part_supp_ds},
                 {supplier_ds},

--- a/queries/polars/q11.py
+++ b/queries/polars/q11.py
@@ -3,6 +3,9 @@ from typing import Any
 import polars as pl
 
 from queries.polars import utils
+from settings import Settings
+
+settings = Settings()
 
 Q_NUM = 11
 
@@ -23,7 +26,7 @@ def q(
     assert supplier is not None
 
     var1 = "GERMANY"
-    var2 = 0.0001
+    var2 = 0.0001 / settings.scale_factor
 
     q1 = (
         partsupp.join(supplier, left_on="ps_suppkey", right_on="s_suppkey")

--- a/queries/pyspark/q11.py
+++ b/queries/pyspark/q11.py
@@ -1,10 +1,16 @@
 from queries.pyspark import utils
+from settings import Settings
+
+settings = Settings()
 
 Q_NUM = 11
 
 
 def q() -> None:
-    query_str = """
+    scale_factor = settings.scale_factor
+    fraction = 0.0001 / scale_factor
+
+    query_str = f"""
     select
         ps_partkey,
         round(sum(ps_supplycost * ps_availqty), 2) as value
@@ -20,7 +26,7 @@ def q() -> None:
         ps_partkey having
                 sum(ps_supplycost * ps_availqty) > (
             select
-                sum(ps_supplycost * ps_availqty) * 0.0001
+                sum(ps_supplycost * ps_availqty) * {fraction}
             from
                 partsupp,
                 supplier,


### PR DESCRIPTION
The [TPC-H spec](https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-H_v3.0.1.pdf) (section 2.4.3.11, page 47) defines the `FRACTION` substitution parameter for Q11 as

    FRACTION is chosen as 0.0001 / SF.

Update the queries to make this choice.