### PR TITLE
Add pandas queries q9-q22 and fix caching pattern

### DIFF
--- a/queries/pandas/q1.py
+++ b/queries/pandas/q1.py
@@ -10,13 +10,12 @@ Q_NUM = 1
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
+    line_item_ds_fn = utils.get_line_item_ds
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
+    line_item_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        line_item_ds = line_item_ds()
+        line_item_ds = line_item_ds_fn()
 
         var1 = date(1998, 9, 2)
 

--- a/queries/pandas/q10.py
+++ b/queries/pandas/q10.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 10
+
+
+def q() -> None:
+    customer_ds_fn = utils.get_customer_ds
+    lineitem_ds_fn = utils.get_line_item_ds
+    nation_ds_fn = utils.get_nation_ds
+    orders_ds_fn = utils.get_orders_ds
+
+    # first call one time to cache in case we don't include the IO times
+    customer_ds_fn()
+    lineitem_ds_fn()
+    nation_ds_fn()
+    orders_ds_fn()
+
+    def query() -> pd.DataFrame:
+        customer_ds = customer_ds_fn()
+        lineitem_ds = lineitem_ds_fn()
+        nation_ds = nation_ds_fn()
+        orders_ds = orders_ds_fn()
+
+        var1 = pd.Timestamp("1993-10-01")
+        var2 = pd.Timestamp("1994-01-01")
+
+        jn1 = customer_ds.merge(orders_ds, left_on="c_custkey", right_on="o_custkey")
+        jn2 = jn1.merge(lineitem_ds, left_on="o_orderkey", right_on="l_orderkey")
+        jn3 = jn2.merge(nation_ds, left_on="c_nationkey", right_on="n_nationkey")
+
+        jn3 = jn3[(jn3["o_orderdate"] >= var1) & (jn3["o_orderdate"] < var2)]
+        jn3 = jn3[jn3["l_returnflag"] == "R"]
+
+        jn3["revenue"] = jn3["l_extendedprice"] * (1 - jn3["l_discount"])
+
+        gb = jn3.groupby(
+            [
+                "c_custkey",
+                "c_name",
+                "c_acctbal",
+                "c_phone",
+                "n_name",
+                "c_address",
+                "c_comment",
+            ],
+            as_index=False,
+        )
+        agg = gb.agg(revenue=pd.NamedAgg(column="revenue", aggfunc="sum"))
+
+        sel = agg.loc[
+            :,
+            [
+                "c_custkey",
+                "c_name",
+                "revenue",
+                "c_acctbal",
+                "n_name",
+                "c_address",
+                "c_phone",
+                "c_comment",
+            ],
+        ]
+
+        result_df = sel.sort_values("revenue", ascending=False).head(20)
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q11.py
+++ b/queries/pandas/q11.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+from settings import Settings
+
+Q_NUM = 11
+
+settings = Settings()
+
+
+def q() -> None:
+    nation_ds_fn = utils.get_nation_ds
+    part_supp_ds_fn = utils.get_part_supp_ds
+    supplier_ds_fn = utils.get_supplier_ds
+
+    # first call one time to cache in case we don't include the IO times
+    nation_ds_fn()
+    part_supp_ds_fn()
+    supplier_ds_fn()
+
+    def query() -> pd.DataFrame:
+        nation_ds = nation_ds_fn()
+        part_supp_ds = part_supp_ds_fn()
+        supplier_ds = supplier_ds_fn()
+
+        var1 = "GERMANY"
+        var2 = 0.0001 / settings.scale_factor
+
+        jn1 = part_supp_ds.merge(
+            supplier_ds, left_on="ps_suppkey", right_on="s_suppkey"
+        )
+        jn2 = jn1.merge(nation_ds, left_on="s_nationkey", right_on="n_nationkey")
+        jn2 = jn2[jn2["n_name"] == var1]
+
+        jn2["value"] = jn2["ps_supplycost"] * jn2["ps_availqty"]
+
+        threshold = jn2["value"].sum() * var2
+
+        gb = jn2.groupby("ps_partkey", as_index=False)
+        agg = gb.agg(value=pd.NamedAgg(column="value", aggfunc="sum"))
+
+        result = agg[agg["value"] > threshold]
+        result_df = result.sort_values("value", ascending=False)
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q12.py
+++ b/queries/pandas/q12.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 12
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    orders_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        orders_ds = orders_ds_fn()
+
+        var1 = "MAIL"
+        var2 = "SHIP"
+        var3 = pd.Timestamp("1994-01-01")
+        var4 = pd.Timestamp("1995-01-01")
+
+        jn = orders_ds.merge(lineitem_ds, left_on="o_orderkey", right_on="l_orderkey")
+
+        jn = jn[jn["l_shipmode"].isin([var1, var2])]
+        jn = jn[jn["l_commitdate"] < jn["l_receiptdate"]]
+        jn = jn[jn["l_shipdate"] < jn["l_commitdate"]]
+        jn = jn[(jn["l_receiptdate"] >= var3) & (jn["l_receiptdate"] < var4)]
+
+        jn["high_line_count"] = jn["o_orderpriority"].isin(["1-URGENT", "2-HIGH"])
+        jn["low_line_count"] = ~jn["o_orderpriority"].isin(["1-URGENT", "2-HIGH"])
+
+        gb = jn.groupby("l_shipmode", as_index=False)
+        agg = gb.agg(
+            high_line_count=pd.NamedAgg(column="high_line_count", aggfunc="sum"),
+            low_line_count=pd.NamedAgg(column="low_line_count", aggfunc="sum"),
+        )
+
+        result_df = agg.sort_values("l_shipmode")
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q13.py
+++ b/queries/pandas/q13.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 13
+
+
+def q() -> None:
+    customer_ds_fn = utils.get_customer_ds
+    orders_ds_fn = utils.get_orders_ds
+
+    # first call one time to cache in case we don't include the IO times
+    customer_ds_fn()
+    orders_ds_fn()
+
+    def query() -> pd.DataFrame:
+        customer_ds = customer_ds_fn()
+        orders_ds = orders_ds_fn()
+
+        var1 = "special"
+        var2 = "requests"
+
+        filtered_orders = orders_ds[
+            ~orders_ds["o_comment"].str.contains(
+                f"{var1}.*{var2}", regex=True, na=False
+            )
+        ]
+
+        jn = customer_ds.merge(
+            filtered_orders,
+            left_on="c_custkey",
+            right_on="o_custkey",
+            how="left",
+        )
+
+        gb1 = jn.groupby("c_custkey", as_index=False)
+        agg1 = gb1.agg(c_count=pd.NamedAgg(column="o_orderkey", aggfunc="count"))
+
+        gb2 = agg1.groupby("c_count", as_index=False)
+        agg2 = gb2.size()
+        agg2.columns = ["c_count", "custdist"]
+
+        result_df = agg2.sort_values(
+            by=["custdist", "c_count"], ascending=[False, False]
+        )
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q14.py
+++ b/queries/pandas/q14.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 14
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    part_ds_fn = utils.get_part_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    part_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        part_ds = part_ds_fn()
+
+        var1 = pd.Timestamp("1995-09-01")
+        var2 = pd.Timestamp("1995-10-01")
+
+        jn = lineitem_ds.merge(part_ds, left_on="l_partkey", right_on="p_partkey")
+
+        jn = jn[(jn["l_shipdate"] >= var1) & (jn["l_shipdate"] < var2)]
+
+        jn["revenue"] = jn["l_extendedprice"] * (1 - jn["l_discount"])
+        jn["promo_revenue"] = jn["revenue"].where(
+            jn["p_type"].str.startswith("PROMO"), 0
+        )
+
+        promo_revenue = (100.0 * jn["promo_revenue"].sum() / jn["revenue"].sum()).round(
+            2
+        )
+
+        result_df = pd.DataFrame({"promo_revenue": [promo_revenue]})
+
+        return result_df
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q15.py
+++ b/queries/pandas/q15.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 15
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    supplier_ds_fn = utils.get_supplier_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    supplier_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        supplier_ds = supplier_ds_fn()
+
+        var1 = pd.Timestamp("1996-01-01")
+        var2 = pd.Timestamp("1996-04-01")
+
+        filtered_lineitem = lineitem_ds[
+            (lineitem_ds["l_shipdate"] >= var1) & (lineitem_ds["l_shipdate"] < var2)
+        ]
+
+        filtered_lineitem["revenue"] = filtered_lineitem["l_extendedprice"] * (
+            1 - filtered_lineitem["l_discount"]
+        )
+
+        revenue = filtered_lineitem.groupby("l_suppkey", as_index=False).agg(
+            total_revenue=pd.NamedAgg(column="revenue", aggfunc="sum")
+        )
+        revenue = revenue.rename(columns={"l_suppkey": "supplier_no"})
+
+        max_revenue = revenue["total_revenue"].max()
+
+        jn = supplier_ds.merge(revenue, left_on="s_suppkey", right_on="supplier_no")
+        jn = jn[jn["total_revenue"] == max_revenue]
+
+        result = jn.loc[
+            :, ["s_suppkey", "s_name", "s_address", "s_phone", "total_revenue"]
+        ]
+
+        result_df = result.sort_values("s_suppkey")
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q16.py
+++ b/queries/pandas/q16.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 16
+
+
+def q() -> None:
+    part_ds_fn = utils.get_part_ds
+    part_supp_ds_fn = utils.get_part_supp_ds
+    supplier_ds_fn = utils.get_supplier_ds
+
+    # first call one time to cache in case we don't include the IO times
+    part_ds_fn()
+    part_supp_ds_fn()
+    supplier_ds_fn()
+
+    def query() -> pd.DataFrame:
+        part_ds = part_ds_fn()
+        part_supp_ds = part_supp_ds_fn()
+        supplier_ds = supplier_ds_fn()
+
+        var1 = "Brand#45"
+
+        # Filter suppliers with complaints
+        filtered_supplier = supplier_ds[
+            supplier_ds["s_comment"].str.contains(
+                ".*Customer.*Complaints.*", regex=True, na=False
+            )
+        ][["s_suppkey"]]
+
+        jn = part_ds.merge(part_supp_ds, left_on="p_partkey", right_on="ps_partkey")
+
+        jn = jn[jn["p_brand"] != var1]
+        jn = jn[~jn["p_type"].str.startswith("MEDIUM POLISHED")]
+        jn = jn[jn["p_size"].isin([49, 14, 23, 45, 19, 3, 36, 9])]
+
+        # Left join to exclude suppliers with complaints
+        jn2 = jn.merge(
+            filtered_supplier,
+            left_on="ps_suppkey",
+            right_on="s_suppkey",
+            how="left",
+        )
+        jn2 = jn2[jn2["s_suppkey"].isna()]
+
+        gb = jn2.groupby(["p_brand", "p_type", "p_size"], as_index=False)
+        agg = gb.agg(supplier_cnt=pd.NamedAgg(column="ps_suppkey", aggfunc="nunique"))
+
+        result_df = agg.sort_values(
+            by=["supplier_cnt", "p_brand", "p_type", "p_size"],
+            ascending=[False, True, True, True],
+        )
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q17.py
+++ b/queries/pandas/q17.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 17
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    part_ds_fn = utils.get_part_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    part_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        part_ds = part_ds_fn()
+
+        var1 = "Brand#23"
+        var2 = "MED BOX"
+
+        filtered_part = part_ds[
+            (part_ds["p_brand"] == var1) & (part_ds["p_container"] == var2)
+        ]
+
+        jn = filtered_part.merge(lineitem_ds, left_on="p_partkey", right_on="l_partkey")
+
+        # Calculate average quantity per partkey
+        avg_qty = jn.groupby("p_partkey", as_index=False).agg(
+            avg_quantity=pd.NamedAgg(column="l_quantity", aggfunc="mean")
+        )
+        avg_qty["avg_quantity"] = 0.2 * avg_qty["avg_quantity"]
+
+        jn2 = jn.merge(avg_qty, on="p_partkey")
+        jn2 = jn2[jn2["l_quantity"] < jn2["avg_quantity"]]
+
+        avg_yearly = (jn2["l_extendedprice"].sum() / 7.0).round(2)
+
+        result_df = pd.DataFrame({"avg_yearly": [avg_yearly]})
+
+        return result_df
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q18.py
+++ b/queries/pandas/q18.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 18
+
+
+def q() -> None:
+    customer_ds_fn = utils.get_customer_ds
+    lineitem_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+
+    # first call one time to cache in case we don't include the IO times
+    customer_ds_fn()
+    lineitem_ds_fn()
+    orders_ds_fn()
+
+    def query() -> pd.DataFrame:
+        customer_ds = customer_ds_fn()
+        lineitem_ds = lineitem_ds_fn()
+        orders_ds = orders_ds_fn()
+
+        var1 = 300
+
+        # Find orders with sum quantity > 300
+        qty_by_order = lineitem_ds.groupby("l_orderkey", as_index=False).agg(
+            sum_quantity=pd.NamedAgg(column="l_quantity", aggfunc="sum")
+        )
+        large_orders = qty_by_order[qty_by_order["sum_quantity"] > var1][["l_orderkey"]]
+
+        # Semi join: keep only orders that are in large_orders
+        jn1 = orders_ds.merge(large_orders, left_on="o_orderkey", right_on="l_orderkey")
+        jn2 = jn1.merge(lineitem_ds, left_on="o_orderkey", right_on="l_orderkey")
+        jn3 = jn2.merge(customer_ds, left_on="o_custkey", right_on="c_custkey")
+
+        gb = jn3.groupby(
+            [
+                "c_name",
+                "o_custkey",
+                "o_orderkey",
+                "o_orderdate",
+                "o_totalprice",
+            ],
+            as_index=False,
+        )
+        agg = gb.agg(col6=pd.NamedAgg(column="l_quantity", aggfunc="sum"))
+
+        result = agg.loc[
+            :,
+            [
+                "c_name",
+                "o_custkey",
+                "o_orderkey",
+                "o_orderdate",
+                "o_totalprice",
+                "col6",
+            ],
+        ]
+        result = result.rename(
+            columns={"o_custkey": "c_custkey", "o_orderdate": "o_orderdat"}
+        )
+
+        result_df = result.sort_values(
+            by=["o_totalprice", "o_orderdat"], ascending=[False, True]
+        ).head(100)
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q19.py
+++ b/queries/pandas/q19.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 19
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    part_ds_fn = utils.get_part_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    part_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        part_ds = part_ds_fn()
+
+        jn = part_ds.merge(lineitem_ds, left_on="p_partkey", right_on="l_partkey")
+
+        jn = jn[jn["l_shipmode"].isin(["AIR", "AIR REG"])]
+        jn = jn[jn["l_shipinstruct"] == "DELIVER IN PERSON"]
+
+        # Complex filter conditions
+        cond1 = (
+            (jn["p_brand"] == "Brand#12")
+            & jn["p_container"].isin(["SM CASE", "SM BOX", "SM PACK", "SM PKG"])
+            & (jn["l_quantity"] >= 1)
+            & (jn["l_quantity"] <= 11)
+            & (jn["p_size"] >= 1)
+            & (jn["p_size"] <= 5)
+        )
+
+        cond2 = (
+            (jn["p_brand"] == "Brand#23")
+            & jn["p_container"].isin(["MED BAG", "MED BOX", "MED PKG", "MED PACK"])
+            & (jn["l_quantity"] >= 10)
+            & (jn["l_quantity"] <= 20)
+            & (jn["p_size"] >= 1)
+            & (jn["p_size"] <= 10)
+        )
+
+        cond3 = (
+            (jn["p_brand"] == "Brand#34")
+            & jn["p_container"].isin(["LG CASE", "LG BOX", "LG PACK", "LG PKG"])
+            & (jn["l_quantity"] >= 20)
+            & (jn["l_quantity"] <= 30)
+            & (jn["p_size"] >= 1)
+            & (jn["p_size"] <= 15)
+        )
+
+        jn = jn[cond1 | cond2 | cond3]
+
+        revenue = round((jn["l_extendedprice"] * (1 - jn["l_discount"])).sum(), 2)
+
+        result_df = pd.DataFrame({"revenue": [revenue]})
+
+        return result_df
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q2.py
+++ b/queries/pandas/q2.py
@@ -11,30 +11,25 @@ Q_NUM = 2
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds
-    nation_ds = utils.get_nation_ds
-    supplier_ds = utils.get_supplier_ds
-    part_ds = utils.get_part_ds
-    part_supp_ds = utils.get_part_supp_ds
+    region_ds_fn = utils.get_region_ds
+    nation_ds_fn = utils.get_nation_ds
+    supplier_ds_fn = utils.get_supplier_ds
+    part_ds_fn = utils.get_part_ds
+    part_supp_ds_fn = utils.get_part_supp_ds
 
     # first call one time to cache in case we don't include the IO times
-    region_ds()
-    nation_ds()
-    supplier_ds()
-    part_ds()
-    part_supp_ds()
+    region_ds_fn()
+    nation_ds_fn()
+    supplier_ds_fn()
+    part_ds_fn()
+    part_supp_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal region_ds
-        nonlocal nation_ds
-        nonlocal supplier_ds
-        nonlocal part_ds
-        nonlocal part_supp_ds
-        region_ds = region_ds()
-        nation_ds = nation_ds()
-        supplier_ds = supplier_ds()
-        part_ds = part_ds()
-        part_supp_ds = part_supp_ds()
+        region_ds = region_ds_fn()
+        nation_ds = nation_ds_fn()
+        supplier_ds = supplier_ds_fn()
+        part_ds = part_ds_fn()
+        part_supp_ds = part_supp_ds_fn()
 
         var1 = 15
         var2 = "BRASS"

--- a/queries/pandas/q20.py
+++ b/queries/pandas/q20.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 20
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    nation_ds_fn = utils.get_nation_ds
+    part_ds_fn = utils.get_part_ds
+    part_supp_ds_fn = utils.get_part_supp_ds
+    supplier_ds_fn = utils.get_supplier_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    nation_ds_fn()
+    part_ds_fn()
+    part_supp_ds_fn()
+    supplier_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        nation_ds = nation_ds_fn()
+        part_ds = part_ds_fn()
+        part_supp_ds = part_supp_ds_fn()
+        supplier_ds = supplier_ds_fn()
+
+        var1 = pd.Timestamp("1994-01-01")
+        var2 = pd.Timestamp("1995-01-01")
+        var3 = "CANADA"
+        var4 = "forest"
+
+        # Aggregate lineitem by partkey and suppkey
+        filtered_lineitem = lineitem_ds[
+            (lineitem_ds["l_shipdate"] >= var1) & (lineitem_ds["l_shipdate"] < var2)
+        ]
+        qty_agg = filtered_lineitem.groupby(
+            ["l_partkey", "l_suppkey"], as_index=False
+        ).agg(sum_quantity=pd.NamedAgg(column="l_quantity", aggfunc="sum"))
+        qty_agg["sum_quantity"] = qty_agg["sum_quantity"] * 0.5
+
+        # Filter nation
+        filtered_nation = nation_ds[nation_ds["n_name"] == var3]
+
+        # Filter parts starting with "forest"
+        filtered_part = part_ds[part_ds["p_name"].str.startswith(var4)][
+            ["p_partkey"]
+        ].drop_duplicates()
+
+        # Join partsupp with filtered parts
+        jn1 = filtered_part.merge(
+            part_supp_ds, left_on="p_partkey", right_on="ps_partkey"
+        )
+
+        # Join with quantity aggregation
+        jn2 = jn1.merge(
+            qty_agg,
+            left_on=["ps_suppkey", "p_partkey"],
+            right_on=["l_suppkey", "l_partkey"],
+        )
+
+        # Filter by availqty > sum_quantity
+        jn2 = jn2[jn2["ps_availqty"] > jn2["sum_quantity"]]
+
+        # Get unique suppliers
+        unique_suppliers = jn2[["ps_suppkey"]].drop_duplicates()
+
+        # Join with supplier and nation
+        jn3 = unique_suppliers.merge(
+            supplier_ds, left_on="ps_suppkey", right_on="s_suppkey"
+        )
+        jn4 = jn3.merge(filtered_nation, left_on="s_nationkey", right_on="n_nationkey")
+
+        result = jn4.loc[:, ["s_name", "s_address"]]
+
+        result_df = result.sort_values("s_name")
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q21.py
+++ b/queries/pandas/q21.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 21
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    nation_ds_fn = utils.get_nation_ds
+    orders_ds_fn = utils.get_orders_ds
+    supplier_ds_fn = utils.get_supplier_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    nation_ds_fn()
+    orders_ds_fn()
+    supplier_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        nation_ds = nation_ds_fn()
+        orders_ds = orders_ds_fn()
+        supplier_ds = supplier_ds_fn()
+
+        var1 = "SAUDI ARABIA"
+
+        # Find orders with multiple suppliers
+        supp_per_order = lineitem_ds.groupby("l_orderkey", as_index=False).agg(
+            n_supp_by_order=pd.NamedAgg(column="l_suppkey", aggfunc="count")
+        )
+        multi_supp_orders = supp_per_order[supp_per_order["n_supp_by_order"] > 1]
+
+        # Join with lineitem where receiptdate > commitdate
+        late_lineitem = lineitem_ds[
+            lineitem_ds["l_receiptdate"] > lineitem_ds["l_commitdate"]
+        ]
+        jn1 = multi_supp_orders.merge(late_lineitem, on="l_orderkey", how="inner")
+
+        # Re-calculate suppliers per order for the late items
+        supp_per_order2 = jn1.groupby("l_orderkey", as_index=False).agg(
+            n_supp_by_order=pd.NamedAgg(column="l_suppkey", aggfunc="count")
+        )
+
+        # Join back with lineitem data
+        jn2 = supp_per_order2.merge(jn1, on="l_orderkey")
+
+        # Filter to orders where only one supplier was late
+        jn2 = jn2[jn2["n_supp_by_order_x"] == 1]
+
+        # Join with supplier, nation, and orders
+        jn3 = jn2.merge(supplier_ds, left_on="l_suppkey", right_on="s_suppkey")
+        jn4 = jn3.merge(nation_ds, left_on="s_nationkey", right_on="n_nationkey")
+        jn5 = jn4.merge(orders_ds, left_on="l_orderkey", right_on="o_orderkey")
+
+        # Filter by nation and order status
+        jn5 = jn5[jn5["n_name"] == var1]
+        jn5 = jn5[jn5["o_orderstatus"] == "F"]
+
+        # Group by supplier name and count
+        gb = jn5.groupby("s_name", as_index=False)
+        agg = gb.size()
+        agg.columns = ["s_name", "numwait"]
+
+        result_df = agg.sort_values(
+            by=["numwait", "s_name"], ascending=[False, True]
+        ).head(100)
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q22.py
+++ b/queries/pandas/q22.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 22
+
+
+def q() -> None:
+    customer_ds_fn = utils.get_customer_ds
+    orders_ds_fn = utils.get_orders_ds
+
+    # first call one time to cache in case we don't include the IO times
+    customer_ds_fn()
+    orders_ds_fn()
+
+    def query() -> pd.DataFrame:
+        customer_ds = customer_ds_fn()
+        orders_ds = orders_ds_fn()
+
+        # Extract country code (first 2 chars of phone)
+        customer_with_cntry = customer_ds.copy()
+        customer_with_cntry["cntrycode"] = customer_with_cntry["c_phone"].str.slice(
+            0, 2
+        )
+
+        # Filter by country codes
+        filtered_customer = customer_with_cntry[
+            customer_with_cntry["cntrycode"].str.match("13|31|23|29|30|18|17", na=False)
+        ][["c_acctbal", "c_custkey", "cntrycode"]]
+
+        # Calculate average account balance for positive balances
+        avg_acctbal = filtered_customer[filtered_customer["c_acctbal"] > 0.0][
+            "c_acctbal"
+        ].mean()
+
+        # Get unique customer keys from orders
+        customers_with_orders = orders_ds[["o_custkey"]].drop_duplicates()
+
+        # Left join to find customers without orders
+        jn = filtered_customer.merge(
+            customers_with_orders,
+            left_on="c_custkey",
+            right_on="o_custkey",
+            how="left",
+        )
+        jn = jn[jn["o_custkey"].isna()]
+
+        # Filter by account balance > average
+        jn = jn[jn["c_acctbal"] > avg_acctbal]
+
+        # Group by country code
+        gb = jn.groupby("cntrycode", as_index=False)
+        agg = gb.agg(
+            numcust=pd.NamedAgg(column="c_acctbal", aggfunc="count"),
+            totacctbal=pd.NamedAgg(column="c_acctbal", aggfunc="sum"),
+        )
+
+        result_df = agg.sort_values("cntrycode")
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/pandas/q3.py
+++ b/queries/pandas/q3.py
@@ -12,22 +12,19 @@ Q_NUM = 3
 
 
 def q() -> None:
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
 
     # first call one time to cache in case we don't include the IO times
-    customer_ds()
-    line_item_ds()
-    orders_ds()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
 
         var1 = "BUILDING"
         var2 = date(1995, 3, 15)

--- a/queries/pandas/q4.py
+++ b/queries/pandas/q4.py
@@ -10,18 +10,16 @@ Q_NUM = 4
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
 
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
-    orders_ds()
+    line_item_ds_fn()
+    orders_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
 
         var1 = date(1993, 7, 1)
         var2 = date(1993, 10, 1)

--- a/queries/pandas/q5.py
+++ b/queries/pandas/q5.py
@@ -12,34 +12,28 @@ Q_NUM = 5
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds
-    nation_ds = utils.get_nation_ds
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
-    supplier_ds = utils.get_supplier_ds
+    region_ds_fn = utils.get_region_ds
+    nation_ds_fn = utils.get_nation_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    region_ds()
-    nation_ds()
-    customer_ds()
-    line_item_ds()
-    orders_ds()
-    supplier_ds()
+    region_ds_fn()
+    nation_ds_fn()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal region_ds
-        nonlocal nation_ds
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        nonlocal supplier_ds
-        region_ds = region_ds()
-        nation_ds = nation_ds()
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
-        supplier_ds = supplier_ds()
+        region_ds = region_ds_fn()
+        nation_ds = nation_ds_fn()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "ASIA"
         var2 = date(1994, 1, 1)

--- a/queries/pandas/q6.py
+++ b/queries/pandas/q6.py
@@ -10,14 +10,13 @@ Q_NUM = 6
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds
+    line_item_ds_fn = utils.get_line_item_ds
 
     # first call one time to cache in case we don't include the IO times
-    line_item_ds()
+    line_item_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal line_item_ds
-        line_item_ds = line_item_ds()
+        line_item_ds = line_item_ds_fn()
 
         var1 = date(1994, 1, 1)
         var2 = date(1995, 1, 1)

--- a/queries/pandas/q7.py
+++ b/queries/pandas/q7.py
@@ -10,30 +10,25 @@ Q_NUM = 7
 
 
 def q() -> None:
-    nation_ds = utils.get_nation_ds
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    orders_ds = utils.get_orders_ds
-    supplier_ds = utils.get_supplier_ds
+    nation_ds_fn = utils.get_nation_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    orders_ds_fn = utils.get_orders_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    nation_ds()
-    customer_ds()
-    line_item_ds()
-    orders_ds()
-    supplier_ds()
+    nation_ds_fn()
+    customer_ds_fn()
+    line_item_ds_fn()
+    orders_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal nation_ds
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal orders_ds
-        nonlocal supplier_ds
-        nation_ds = nation_ds()
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        orders_ds = orders_ds()
-        supplier_ds = supplier_ds()
+        nation_ds = nation_ds_fn()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        orders_ds = orders_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "FRANCE"
         var2 = "GERMANY"

--- a/queries/pandas/q8.py
+++ b/queries/pandas/q8.py
@@ -12,38 +12,31 @@ Q_NUM = 8
 
 
 def q() -> None:
-    customer_ds = utils.get_customer_ds
-    line_item_ds = utils.get_line_item_ds
-    nation_ds = utils.get_nation_ds
-    orders_ds = utils.get_orders_ds
-    part_ds = utils.get_part_ds
-    region_ds = utils.get_region_ds
-    supplier_ds = utils.get_supplier_ds
+    customer_ds_fn = utils.get_customer_ds
+    line_item_ds_fn = utils.get_line_item_ds
+    nation_ds_fn = utils.get_nation_ds
+    orders_ds_fn = utils.get_orders_ds
+    part_ds_fn = utils.get_part_ds
+    region_ds_fn = utils.get_region_ds
+    supplier_ds_fn = utils.get_supplier_ds
 
     # first call one time to cache in case we don't include the IO times
-    customer_ds()
-    line_item_ds()
-    nation_ds()
-    orders_ds()
-    part_ds()
-    region_ds()
-    supplier_ds()
+    customer_ds_fn()
+    line_item_ds_fn()
+    nation_ds_fn()
+    orders_ds_fn()
+    part_ds_fn()
+    region_ds_fn()
+    supplier_ds_fn()
 
     def query() -> pd.DataFrame:
-        nonlocal customer_ds
-        nonlocal line_item_ds
-        nonlocal nation_ds
-        nonlocal orders_ds
-        nonlocal part_ds
-        nonlocal region_ds
-        nonlocal supplier_ds
-        customer_ds = customer_ds()
-        line_item_ds = line_item_ds()
-        nation_ds = nation_ds()
-        orders_ds = orders_ds()
-        part_ds = part_ds()
-        region_ds = region_ds()
-        supplier_ds = supplier_ds()
+        customer_ds = customer_ds_fn()
+        line_item_ds = line_item_ds_fn()
+        nation_ds = nation_ds_fn()
+        orders_ds = orders_ds_fn()
+        part_ds = part_ds_fn()
+        region_ds = region_ds_fn()
+        supplier_ds = supplier_ds_fn()
 
         var1 = "BRAZIL"
         var2 = "AMERICA"

--- a/queries/pandas/q9.py
+++ b/queries/pandas/q9.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from queries.pandas import utils
+
+Q_NUM = 9
+
+
+def q() -> None:
+    lineitem_ds_fn = utils.get_line_item_ds
+    nation_ds_fn = utils.get_nation_ds
+    orders_ds_fn = utils.get_orders_ds
+    part_ds_fn = utils.get_part_ds
+    part_supp_ds_fn = utils.get_part_supp_ds
+    supplier_ds_fn = utils.get_supplier_ds
+
+    # first call one time to cache in case we don't include the IO times
+    lineitem_ds_fn()
+    nation_ds_fn()
+    orders_ds_fn()
+    part_ds_fn()
+    part_supp_ds_fn()
+    supplier_ds_fn()
+
+    def query() -> pd.DataFrame:
+        lineitem_ds = lineitem_ds_fn()
+        nation_ds = nation_ds_fn()
+        orders_ds = orders_ds_fn()
+        part_ds = part_ds_fn()
+        part_supp_ds = part_supp_ds_fn()
+        supplier_ds = supplier_ds_fn()
+
+        jn1 = part_ds.merge(part_supp_ds, left_on="p_partkey", right_on="ps_partkey")
+        jn2 = jn1.merge(supplier_ds, left_on="ps_suppkey", right_on="s_suppkey")
+        jn3 = jn2.merge(
+            lineitem_ds,
+            left_on=["p_partkey", "ps_suppkey"],
+            right_on=["l_partkey", "l_suppkey"],
+        )
+        jn4 = jn3.merge(orders_ds, left_on="l_orderkey", right_on="o_orderkey")
+        jn5 = jn4.merge(nation_ds, left_on="s_nationkey", right_on="n_nationkey")
+
+        jn5 = jn5[jn5["p_name"].str.contains("green", regex=False)]
+
+        jn5["o_year"] = jn5["o_orderdate"].dt.year
+        jn5["amount"] = jn5["l_extendedprice"] * (1.0 - jn5["l_discount"]) - (
+            jn5["ps_supplycost"] * jn5["l_quantity"]
+        )
+        jn5 = jn5.rename(columns={"n_name": "nation"})
+
+        gb = jn5.groupby(["nation", "o_year"], as_index=False, sort=False)
+        agg = gb.agg(sum_profit=pd.NamedAgg(column="amount", aggfunc="sum"))
+        sorted_df = agg.sort_values(by=["nation", "o_year"], ascending=[True, False])
+        result_df = sorted_df.reset_index(drop=True)
+
+        return result_df  # type: ignore[no-any-return]
+
+    utils.run_query(Q_NUM, query)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/polars/q17.py
+++ b/queries/polars/q17.py
@@ -25,7 +25,7 @@ def q(
     q1 = (
         part.filter(pl.col("p_brand") == var1)
         .filter(pl.col("p_container") == var2)
-        .join(lineitem, how="left", left_on="p_partkey", right_on="l_partkey")
+        .join(lineitem, how="inner", left_on="p_partkey", right_on="l_partkey")
     )
 
     return (


### PR DESCRIPTION
Supersedes #156. The `nonlocal` pattern caused the `query()` to fail when run twice (cold run then hot run). Eg. In Q1, on the second call, `line_item_ds` is a DataFrame which we attempt to call -> failure.


The new queries are largely copied from https://github.com/rapidsai/cudf/pull/21108. And I used to claude to convert the queries from our structure in polars[gpu] to the structure here.