### PR TITLE
fix: Use generic `round` on two Pandas tests

### DIFF
--- a/queries/pandas/q14.py
+++ b/queries/pandas/q14.py
@@ -31,8 +31,8 @@ def q() -> None:
             jn["p_type"].str.startswith("PROMO"), 0
         )
 
-        promo_revenue = (100.0 * jn["promo_revenue"].sum() / jn["revenue"].sum()).round(
-            2
+        promo_revenue = round(
+            100.0 * jn["promo_revenue"].sum() / jn["revenue"].sum(), 2
         )
 
         result_df = pd.DataFrame({"promo_revenue": [promo_revenue]})

--- a/queries/pandas/q17.py
+++ b/queries/pandas/q17.py
@@ -37,7 +37,7 @@ def q() -> None:
         jn2 = jn.merge(avg_qty, on="p_partkey")
         jn2 = jn2[jn2["l_quantity"] < jn2["avg_quantity"]]
 
-        avg_yearly = (jn2["l_extendedprice"].sum() / 7.0).round(2)
+        avg_yearly = round(jn2["l_extendedprice"].sum() / 7.0, 2)
 
         result_df = pd.DataFrame({"avg_yearly": [avg_yearly]})
 


### PR DESCRIPTION
(Otherwise those two tests seem to fail with the latest versions of the benchmark libs).

---

**Note:** safe to merge - the lint issues are fixed in #188.